### PR TITLE
Editing statusCode assignment for onPreRelease event (line 50). Hapi 3.x...

### DIFF
--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -47,7 +47,7 @@ module.exports.register = function (plugin, options, next) {
 	plugin.ext('onPreResponse', function (request, next) {
 		var startDate = cache.get(request.id);
 		if (startDate) {
-			var statusCode = request.response()._code || request.response().response.code || 'unknown';
+			var statusCode = request.response.statusCode || 'unknown';
 			var statName = settings.template
 							.replace('{path}', normalizePath(request._route.path))
 							.replace('{method}', request.method.toUpperCase())


### PR DESCRIPTION
Hapi 3.x request request object seems to have changed structure. request.response is now an object rather than a function.
