### PR TITLE
Expose statsd client to hapi server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![NPM](https://nodei.co/npm/hapi-statsd.png?downloads=true&stars=true)](https://nodei.co/npm/hapi-statsd/)
 
-A hapi plugin for sending request round trip metrics to statsd
+A hapi plugin for sending request round trip metrics to statsd, also exposing statsd client to the server.
 
 ## Contributing
 
@@ -99,6 +99,14 @@ server.route({
 would send an increment and timing stat to statsd with the following stat name (assuming all options are set to their defaults):
 
 	hapi.test_{param}.GET.200
+
+As the [statsd client](https://github.com/msiebuhr/node-statsd-client) is also exposed to the hapi server, you can use any of its methods, e.g.:
+
+```js
+server.statsd.increment('systemname.subsystem.value');
+server.statsd.gauge('what.you.gauge', 100);
+server.statsd.set('your.set', 200);
+```
 
 ## Version Compatibility
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -27,6 +27,8 @@ module.exports.register = function (server, options, next) {
 			return path.replace(/\//g, settings.pathSeparator);
 		};
 
+	server.decorate('server', 'statsd', statsdClient);
+
 	server.ext('onRequest', function (request, reply) {
 		cache.put(request.id, new Date(), 300, false);
 		return reply.continue();
@@ -36,7 +38,7 @@ module.exports.register = function (server, options, next) {
 		var startDate = cache.get(request.id);
 		if (startDate) {
 			var statusCode = (request.response.isBoom) ? request.response.output.statusCode : request.response.statusCode;
-			
+
 			var path = request._route.path;
 			var specials = request.connection._router.specials;
 
@@ -51,7 +53,7 @@ module.exports.register = function (server, options, next) {
 							.replace('{path}', normalizePath(path))
 							.replace('{method}', request.method.toUpperCase())
 							.replace('{statusCode}', statusCode);
-			
+
 			statName = (statName.indexOf('.') === 0) ? statName.substr(1) : statName;
 			statsdClient.increment(statName);
 			statsdClient.timing(statName, startDate);

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -20,8 +20,8 @@ var assert = require('assert'),
 beforeEach(function(done) {
 	server = new Hapi.Server();
 
-	server.connection({ 
-		host: 'localhost', 
+	server.connection({
+		host: 'localhost',
 		port: 8085,
 		routes: { cors: true }
 	});
@@ -45,6 +45,11 @@ beforeEach(function(done) {
 });
 
 describe('hapi-statsd plugin tests', function() {
+
+	it('should expose statsd client to the hapi server', function() {
+
+		assert.equal(server.statsd, mockStatsdClient);
+	});
 
 	it('should report stats with no path in stat name', function(done) {
 


### PR DESCRIPTION
If you want to track more than just requests with statsd, this PR exposes the client to the hapi server (via `server.decorate()`), so you can use any statsd client methods on top:

```js
server.route({
	method: 'GET',
	path: '/test/{param}',
	handler: function(request, reply) {
		request.server.statsd.increment('success');
		reply('Success!');
	}
});
```

or somewhere else in your application:

```js
server.statsd.gauge('what.you.gauge', 100);
```