### PR TITLE
Update to Hapi v13

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ server.statsd.set('your.set', 200);
 
 ## Version Compatibility
 
-### Currently compatible with: Hapi 11.x.x (Node v4)
+### Currently compatible with: Hapi 13.x.x (Node v4)
 
 * 0.1.x - Hapi 1.x.x
 * 0.2.x - Hapi 3.x.x
@@ -122,6 +122,7 @@ server.statsd.set('your.set', 200);
 * 2.x.x - Hapi 9.x.x
 * 3.x.x - Hapi 10.x.x (Node v4)
 * 4.x.x - Hapi 11.x.x
+* 5.x.x - Hapi 13.x.x
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "4.0.1",
+	"version": "5.0.0",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"eidetic": "0.x.x",
@@ -16,12 +16,12 @@
 		"travis-cov": "0.x.x",
 		"blanket": "1.x.x",
 		"node-dependencies": "0.x.x",
-		"hapi": "^11.0.0",
+		"hapi": "^13.0.0",
 		"coveralls": "2.x.x",
 		"mocha-lcov-reporter": "0.x.x"
 	},
 	"peerDependencies": {
-		"hapi": "^11.0.0"
+		"hapi": "^13.0.0"
 	},
 	"keywords": [
 		"hapi",


### PR DESCRIPTION
I'm aware of #14, but maybe it makes sense to separate the Hapi update from the other changes in that PR? If not, feel free to ignore this.
Bumped the major version to 5 to be consistent with the previous Hapi peer dependency updates.