### PR TITLE
Add filter options to the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,38 @@ The prefix to add to every stat collected. Usually used for grouping a set of st
 
 A character or set of characters to replace the '/' (forward slash) characters in your URL path since forward slashes cannot be used in stat names. Defaults to `'_'`
 
+### `defaultFilter`
+
+Defines whether increment and timer stats are turned on by default. Defaults to `{ enableCounter: true, enableTimer: true }`.
+
+### `filters`
+
+An array of custom filters. A match is determined as follows:
+
+* Check if the filter has an `id` field and see if it matches the route's unique ID
+* Check for `path`, `method` and `status` matching the route and response
+  * Omitting `path`, `method` or `status` results in a wildcard behavior matching of anything
+
+In addition to matching, the field can contain the following configuration options:
+
+* name: Defines a custom name for the stat to be reported
+* enableTimer: Enable/disable the timer stat from being reported
+* enableCounter: Enable/disable the count stat from being reported
+
+Example configuration:
+```js
+defaultFilter: { // by default, enable timer and disable counter stats
+    enableCounter: false,
+    enableTimer: true,
+}
+filters: [
+    { path: '/', enableCounter: true }, // enable counters (keep timers on as well) for this path
+    { path: '/test/{param}', enableCounter: true }, // path with a parameter
+    { path: '/rename', name: 'rename_stat' }, // rename the metric
+    { id: 'match-my-id', enableCounter: true, enableTimer: true }, // match by route id
+    { status: 407, name: 'match_on_status', enableCounter: true, enableTimer: true }, // match by status code
+]
+````
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,14 @@ Defines whether increment and timer stats are turned on by default. Defaults to 
 
 ### `filters`
 
-An array of custom filters. A match is determined as follows:
-
-* Check if the filter has an `id` field and see if it matches the route's unique ID
-* Check for `path`, `method` and `status` matching the route and response
-  * Omitting `path`, `method` or `status` results in a wildcard behavior matching of anything
+An array of custom filters. A successful match requires one of these fields to be defined and match the route: 
+* `id`: The route id defined in the route's config
+* `path`: The path defined in the route
+* `method`: The HTTP method of the request/route
+* `status`: The returned HTTP status code of the response
+ 
+Parameters that are not included are considered wildcard and will match all values. Note that if none of these 
+parameters are included in the filter, then you will get a match on ALL route-response combinations.
 
 In addition to matching, the field can contain the following configuration options:
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -6,10 +6,15 @@ var StatsdClient = require('statsd-client'),
 		port: '8125',
 		prefix: 'hapi',
 		pathSeparator: '_',
-		template: '{path}.{method}.{statusCode}'
+		template: '{path}.{method}.{statusCode}',
+		defaultFilter: {
+			enableCounter: true,
+			enableTimer: true,
+		},
+		filters: [],
 	};
 
-module.exports.register = function (server, options, next) {
+module.exports.register = function(server, options, next) {
 	var settings = Hoek.applyToDefaults(defaults, options || {}),
 		statsdClient = options.statsdClient || new StatsdClient({
 			host: settings.host,
@@ -19,6 +24,37 @@ module.exports.register = function (server, options, next) {
 		normalizePath = function(path) {
 			path = (path.indexOf('/') === 0) ? path.substr(1) : path;
 			return path.replace(/\//g, settings.pathSeparator);
+		},
+		filterCache = {}, //cache results so that we don't have to compute them every time
+		getFilter = function(statName, route, status) {
+			var cachedFilter = filterCache[statName];
+			if(cachedFilter) {
+				return cachedFilter;
+			}
+
+			var foundFilter = settings.filters.find(function(filter) {
+				// a match on route id
+				if (route.settings && route.settings.id && route.settings.id === filter.id) {
+					return true;
+				}
+
+				if (filter.path && route.path !== filter.path) {
+					return false;
+				}
+
+				if (filter.status && status !== filter.status) {
+					return false;
+				}
+
+				if (filter.method && route.method.toUpperCase() !== filter.method.toUpperCase()) {
+					return false;
+				}
+
+				// return true if at least one of the parameters is defined
+				return filter.path || filter.method || filter.status;
+			});
+
+			return filterCache[statName] = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});
 		};
 
 	server.decorate('server', 'statsd', statsdClient);
@@ -36,7 +72,7 @@ module.exports.register = function (server, options, next) {
 		else if (specials.options && request._route === specials.options.route) {
 			path = '/{cors*}';
 		}
-		else if (request._route.path === '/' && request._route.method === 'options'){
+		else if (request._route.path === '/' && request._route.method === 'options') {
 			path = '/{cors*}';
 		}
 
@@ -46,8 +82,19 @@ module.exports.register = function (server, options, next) {
 			.replace('{statusCode}', statusCode);
 
 		statName = (statName.indexOf('.') === 0) ? statName.substr(1) : statName;
-		statsdClient.increment(statName);
-		statsdClient.timing(statName, startDate);
+
+		var filter = getFilter(statName, request._route, statusCode);
+		if (filter.name) {
+			statName = filter.name;
+		}
+
+		if (filter.enableCounter) {
+			statsdClient.increment(statName);
+		}
+
+		if (filter.enableTimer) {
+			statsdClient.timing(statName, startDate);
+		}
 
 		reply.continue();
 	});

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -33,9 +33,8 @@ module.exports.register = function(server, options, next) {
 			}
 
 			var foundFilter = settings.filters.find(function(filter) {
-				// a match on route id
-				if (route.settings && route.settings.id && route.settings.id === filter.id) {
-					return true;
+				if (filter.id && route.settings && route.settings.id !== filter.id) {
+					return false;
 				}
 
 				if (filter.path && route.path !== filter.path) {
@@ -50,8 +49,8 @@ module.exports.register = function(server, options, next) {
 					return false;
 				}
 
-				// return true if at least one of the parameters is defined
-				return filter.path || filter.method || filter.status;
+				// If none of the above checks failed, then we have a match
+				return true;
 			});
 
 			return filterCache[statName] = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "5.0.1",
+	"version": "5.1.0",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"hoek": "3.x.x"

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -18,6 +18,9 @@ var assert = require('assert'),
 	Hapi = require('hapi');
 
 beforeEach(function(done) {
+	mockStatsdClient.incStat = '';
+	mockStatsdClient.timingStat = '';
+	mockStatsdClient.timingDate = '';
 	server = new Hapi.Server();
 
 	server.connection({
@@ -33,26 +36,50 @@ beforeEach(function(done) {
 		reply(new Error());
 	};
 
-	server.route({ method: ['GET','OPTIONS'], path: '/', handler: get, config: {cors: true}});
+	var err407 = function (request, reply) {
+		reply('error').statusCode = 407;
+	};
+
+	server.route({ method: ['GET','OPTIONS'], path: '/', handler: get, config: {cors: true} });
 	server.route({ method: 'GET', path: '/err', handler: err, config: {cors: true} });
-	server.route({ method: 'GET', path: '/test/{param}', handler: get, config: {cors: true}});
+	server.route({ method: 'GET', path: '/test/{param}', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/default', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/override', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/rename', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/match/id', handler: get, config: {id: 'match-my-id', cors: true} });
+	server.route({ method: 'POST', path: '/match/method', handler: get, config: { cors: true} });
+	server.route({ method: 'GET', path: '/match/status', handler: err407, config: { cors: true} });
 
 	server.register({
 		register: plugin,
-		options: { statsdClient: mockStatsdClient }
+		options: {
+			statsdClient: mockStatsdClient,
+			defaultFilter: {
+				enableCounter: false,
+				enableTimer: true,
+			},
+			filters: [
+				{ path: '/', enableCounter: true },
+				{ path: '/err', enableCounter: true },
+				{ path: '/test/{param}', enableCounter: true },
+				{ path: '/override', enableCounter: true, enableTimer: false },
+				{ path: '/rename', name: 'rename_stat', enableCounter: true, enableTimer: true },
+				{ id: 'match-my-id', name: 'match_id_stat', enableCounter: true, enableTimer: true },
+				{ method: 'POST', name: 'match_on_post', enableCounter: true, enableTimer: true },
+				{ status: 407, name: 'match_on_status', enableCounter: true, enableTimer: true },
+			],
+		},
 	}, done);
 });
 
 describe('hapi-statsd plugin tests', function() {
 
 	it('should expose statsd client to the hapi server', function() {
-
 		assert.equal(server.statsd, mockStatsdClient);
 	});
 
 	it('should report stats with no path in stat name', function(done) {
-
-		server.inject('/', function (res) {
+		server.inject('/', function(res) {
 			assert(mockStatsdClient.incStat == 'GET.200');
 			assert(mockStatsdClient.timingStat == 'GET.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -60,9 +87,67 @@ describe('hapi-statsd plugin tests', function() {
 		});
 	});
 
-	it('should report stats with path in stat name', function(done) {
+	it('should honor default filter', function(done) {
+		server.inject('/default', function(res) {
+			assert(mockStatsdClient.incStat == '');
+			assert(mockStatsdClient.timingStat == 'default.GET.200');
+			assert(mockStatsdClient.timingDate instanceof Date);
+			done();
+		});
+	});
 
-		server.inject('/test/123', function (res) {
+	it('should honor filter override', function(done) {
+		server.inject('/override', function(res) {
+			assert(mockStatsdClient.incStat == 'override.GET.200');
+			assert(mockStatsdClient.timingStat == '');
+			done();
+		});
+	});
+
+	it('should use cached value', function(done) {
+		server.inject('/override', function() {
+			server.inject('/override', function() {
+				assert(mockStatsdClient.incStat == 'override.GET.200');
+				assert(mockStatsdClient.timingStat == '');
+				done();
+			});
+		});
+	});
+
+	it('should rename stat', function(done) {
+		server.inject('/rename', function(res) {
+			assert(mockStatsdClient.incStat == 'rename_stat');
+			assert(mockStatsdClient.timingStat == 'rename_stat');
+			done();
+		});
+	});
+
+	it('should match on route id', function(done) {
+		server.inject('/match/id', function(res) {
+			assert(mockStatsdClient.incStat == 'match_id_stat');
+			assert(mockStatsdClient.timingStat == 'match_id_stat');
+			done();
+		});
+	});
+
+	it('should match on request method', function(done) {
+		server.inject({method: 'POST', url: '/match/method'}, function(res) {
+			assert(mockStatsdClient.incStat == 'match_on_post');
+			assert(mockStatsdClient.timingStat == 'match_on_post');
+			done();
+		});
+	});
+
+	it('should match on status code', function(done) {
+		server.inject('/match/status', function(res) {
+			assert(mockStatsdClient.incStat == 'match_on_status');
+			assert(mockStatsdClient.timingStat == 'match_on_status');
+			done();
+		});
+	});
+
+	it('should report stats with path in stat name', function(done) {
+		server.inject('/test/123', function(res) {
 			assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
 			assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -71,8 +156,8 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should report stats with generic not found path', function(done) {
-		server.inject('/fnord', function (res) {
-			assert(mockStatsdClient.incStat == '{notFound*}.GET.404');
+		server.inject('/fnord', function(res) {
+			assert(mockStatsdClient.incStat == '');
 			assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
 			assert(mockStatsdClient.timingDate instanceof Date);
 			done();
@@ -86,7 +171,7 @@ describe('hapi-statsd plugin tests', function() {
 				Origin: 'http://test.domain.com'
 			},
 			url: '/'
-		}, function (res) {
+		}, function(res) {
 			assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200');
 			assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -95,8 +180,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should not change the status code of a response', function(done) {
-
-		server.inject('/err', function (res) {
+		server.inject('/err', function(res) {
 			assert(res.statusCode === 500);
 			done();
 		});


### PR DESCRIPTION
These changes add the following two options to the configuration of this plugin:
- `filters`: An array of filters that can modify the behavior of matching routes
- `defaultFilter`: Defines a default behavior, specifically to override the default of logging everything to statsd

The following parameters can be changed via filters:
- `name`: The name of the metric
- `enableCounter`: Controls whether or not the counter is incremented
- `enableTimer`: Controls whether or not the timer metric is sent to statsd

Documentation is added to the README and unit tests are updated.

Also, the plugin should continue to work as it did before for users that don't leverage these new config options.

@mac- Please review and let me know if you'd like anything changed.