### PR TITLE
Updating to Hapi 17.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 4
+  - 8

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ server.statsd.set('your.set', 200);
 * 4.x.x - Hapi 11.x.x
 * 5.x.x - Hapi 13.x.x
 * 6.x.x - Hapi 16.x.x
+* 7.x.x - Hapi 17.x.x (Node v8)
 
 # License
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -9,7 +9,7 @@ var StatsdClient = require('statsd-client'),
 		template: '{path}.{method}.{statusCode}'
 	};
 
-module.exports.register = function (server, options, next) {
+var register = function (server, options) {
 	var settings = Hoek.applyToDefaults(defaults, options || {}),
 		statsdClient = options.statsdClient || new StatsdClient({
 			host: settings.host,
@@ -23,12 +23,12 @@ module.exports.register = function (server, options, next) {
 
 	server.decorate('server', 'statsd', statsdClient);
 
-	server.ext('onPreResponse', function (request, reply) {
+	server.ext('onPreResponse', function (request, h) {
 		var startDate = new Date(request.info.received);
 		var statusCode = (request.response.isBoom) ? request.response.output.statusCode : request.response.statusCode;
 
 		var path = request._route.path;
-		var specials = request.connection._router.specials;
+		var specials = request._core.router.specials;
 
 		if (request._route === specials.notFound.route) {
 			path = '/{notFound*}';
@@ -49,12 +49,18 @@ module.exports.register = function (server, options, next) {
 		statsdClient.increment(statName);
 		statsdClient.timing(statName, startDate);
 
-		reply.continue();
+		return h.continue;
 	});
 
-	next();
 };
 
-module.exports.register.attributes = {
-	pkg: require('../package.json')
+var pkg = require('../package.json');
+var name = pkg['name'];
+var version = pkg['version'];
+
+exports.plugin = {
+  register: register,
+  name: name,
+  version: version,
+  pkg: pkg
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1459 @@
+{
+	"name": "hapi-statsd",
+	"version": "7.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"accept": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
+			"integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"acorn": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+			"integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
+			"dev": true
+		},
+		"ammo": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.0.tgz",
+			"integrity": "sha512-6yoz9MXYV9sgCHrwprHWPxBaJ9/roQRfXzS//4JCNgKfPYcghFNwJQKBt6vWOoSGGRHsP6qsLJ+xtKStKJWdLQ==",
+			"dev": true,
+			"requires": {
+				"boom": "6.0.0",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-6.0.0.tgz",
+					"integrity": "sha512-LYLa8BmiiOWjvxTMVh73lcZzd2E5yczrKvxAny1UuzO2tkarLrw4tdp3rdfmus3+YfKcZP0vRSM3Obh+fGK6eA==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
+		},
+		"b64": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/b64/-/b64-4.0.0.tgz",
+			"integrity": "sha512-EhmUQodKB0sdzPPrbIWbGqA5cQeTWxYrAgNeeT1rLZWtD3tbNTnphz8J4vkXI3cPgBNlXBjzEbzDzq0Nwi4f9A==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"big-time": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.0.tgz",
+			"integrity": "sha512-OXsmBxlRLwUc65MLta2EOyMTLcjZQkxHkJ81lVPeyVqZag8zhUfKRYIbF3E/IW/LWR8kf8a1GlRYkBXKVGqJOw==",
+			"dev": true
+		},
+		"blanket": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/blanket/-/blanket-1.2.3.tgz",
+			"integrity": "sha1-FRtJh8O9hFUrtfA7kO9fflkx5HM=",
+			"dev": true,
+			"requires": {
+				"acorn": "1.2.2",
+				"falafel": "1.2.0",
+				"foreach": "2.0.5",
+				"isarray": "0.0.1",
+				"object-keys": "1.0.11",
+				"xtend": "4.0.1"
+			}
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "2.16.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+					"dev": true
+				}
+			}
+		},
+		"bounce": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
+			"integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"call": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
+			"integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"caseless": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+			"dev": true
+		},
+		"catbox": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
+			"integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"bounce": "1.2.0",
+				"hoek": "5.0.2",
+				"joi": "13.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"catbox-memory": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.1.tgz",
+			"integrity": "sha512-fl6TI/uneeUb9NGClKWZWkpCZQrkPmuVz/Jaqqb15vqW6KGfJ/vMP/ZMp8VgAkyTrrRvFHbFcS67sbU7EkvbhQ==",
+			"dev": true,
+			"requires": {
+				"big-time": "2.0.0",
+				"boom": "7.1.1",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			}
+		},
+		"cli": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+			"dev": true,
+			"requires": {
+				"exit": "0.1.2",
+				"glob": "7.1.2"
+			}
+		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+			"integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"dev": true,
+			"requires": {
+				"date-now": "0.1.4"
+			}
+		},
+		"content": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/content/-/content-4.0.3.tgz",
+			"integrity": "sha512-BrMfT1xXZHaXyPT/sneXc3IQzh8uL15JWV1R5tU0xo4sBGjF7BN+IRi9WoQLSbfNEs7bJ3E69rjxBKg/RL7lOQ==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"coveralls": {
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+			"integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+			"dev": true,
+			"requires": {
+				"js-yaml": "3.6.1",
+				"lcov-parse": "0.0.10",
+				"log-driver": "1.2.5",
+				"minimist": "1.2.0",
+				"request": "2.79.0"
+			}
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"diff": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
+		},
+		"dom-serializer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1.1.3",
+				"entities": "1.1.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+					"dev": true
+				},
+				"entities": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+					"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+					"dev": true
+				}
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"dev": true
+		},
+		"domhandler": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+			"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1.3.0"
+			}
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"dev": true,
+			"requires": {
+				"dom-serializer": "0.1.0",
+				"domelementtype": "1.3.0"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"entities": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+			"dev": true
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"falafel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+			"integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
+			"dev": true,
+			"requires": {
+				"acorn": "1.2.2",
+				"foreach": "2.0.5",
+				"isarray": "0.0.1",
+				"object-keys": "1.0.11"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.17"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
+			"requires": {
+				"is-property": "1.0.2"
+			}
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"growl": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
+		},
+		"hapi": {
+			"version": "17.1.1",
+			"resolved": "https://registry.npmjs.org/hapi/-/hapi-17.1.1.tgz",
+			"integrity": "sha512-KuZEpq8CQEMCWqJOVk//Kq1TQFlWoUHB4CLe3KBkOqRa2OWMa/A/StH37fJRDTkZvPWIKNIN94O2J0yfITE8QQ==",
+			"dev": true,
+			"requires": {
+				"accept": "3.0.2",
+				"ammo": "3.0.0",
+				"boom": "7.1.1",
+				"bounce": "1.2.0",
+				"call": "5.0.1",
+				"catbox": "10.0.2",
+				"catbox-memory": "3.1.1",
+				"heavy": "6.0.0",
+				"hoek": "5.0.2",
+				"joi": "13.0.2",
+				"mimos": "4.0.0",
+				"podium": "3.1.2",
+				"shot": "4.0.4",
+				"statehood": "6.0.5",
+				"subtext": "6.0.7",
+				"teamwork": "3.0.1",
+				"topo": "3.0.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"har-validator": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"commander": "2.12.2",
+				"is-my-json-valid": "2.16.1",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"dev": true
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "2.16.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+					"dev": true
+				}
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
+		},
+		"heavy": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/heavy/-/heavy-6.0.0.tgz",
+			"integrity": "sha512-iswuGt0zTjFRiltTEw+y1c+9cFroh5nUei9aVy1ToPpscs2DRQuHNKpaRdcjaCJNEuKVQYVyDx4ytEpzpZnQgg==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"hoek": "5.0.2",
+				"joi": "13.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"hoek": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+			"integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
+		},
+		"htmlparser2": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+			"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1.3.0",
+				"domhandler": "2.3.0",
+				"domutils": "1.5.1",
+				"entities": "1.0.0",
+				"readable-stream": "1.1.14"
+			}
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"iron": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
+			"integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"cryptiles": "4.1.1",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				},
+				"cryptiles": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
+					"integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
+					"dev": true,
+					"requires": {
+						"boom": "7.1.1"
+					}
+				}
+			}
+		},
+		"is-my-json-valid": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+			"dev": true,
+			"requires": {
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
+		},
+		"isemail": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
+			"integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+			"dev": true,
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+					"dev": true
+				}
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"joi": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
+			"integrity": "sha512-kVka3LaHQyENvcMW4WJPSepGM43oCofcKxfs9HbbKd/FrwBAAt4lNNTPKOzSMmV53GIspmNO4U3O2TzoGvxxCA==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2",
+				"isemail": "3.0.0",
+				"topo": "3.0.0"
+			}
+		},
+		"js-yaml": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+			"integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "2.7.3"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
+			"optional": true
+		},
+		"jshint": {
+			"version": "2.9.5",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+			"integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+			"dev": true,
+			"requires": {
+				"cli": "1.0.1",
+				"console-browserify": "1.1.0",
+				"exit": "0.1.2",
+				"htmlparser2": "3.8.3",
+				"lodash": "3.7.0",
+				"minimatch": "3.0.4",
+				"shelljs": "0.3.0",
+				"strip-json-comments": "1.0.4"
+			}
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"lcov-parse": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
+		},
+		"lodash": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+			"integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+			"dev": true
+		},
+		"log-driver": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+			"dev": true
+		},
+		"mime-db": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.17",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.30.0"
+			}
+		},
+		"mimos": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
+			"integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2",
+				"mime-db": "1.30.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"mocha": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+			"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.11.0",
+				"debug": "3.1.0",
+				"diff": "3.3.1",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.3",
+				"he": "1.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "4.4.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"mocha-lcov-reporter": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-0.0.2.tgz",
+			"integrity": "sha1-rdE60kFYQxVwytpELGFO3F5P65U=",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"nigel": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.0.tgz",
+			"integrity": "sha512-ufFVFCe1zS/pfIQzQNa5uJxB8v8IcVTUn1zyPvQwb4CQGRxxBfdQPSXpEnI6ZzIwbV5L+GuAoRhYgcVSvTO7fA==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2",
+				"vise": "3.0.0"
+			}
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"pez": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pez/-/pez-4.0.1.tgz",
+			"integrity": "sha512-0c/SoW5MY7lPdc5U1Q/ixyjLZbluGWJonHVmn4mKwSq7vgO9+a9WzoCopHubIwkot6Q+fevNVElaA+1M9SqHrA==",
+			"dev": true,
+			"requires": {
+				"b64": "4.0.0",
+				"boom": "7.1.1",
+				"content": "4.0.3",
+				"hoek": "5.0.2",
+				"nigel": "3.0.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"podium": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
+			"integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2",
+				"joi": "13.0.2"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+			"dev": true
+		},
+		"readable-stream": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"dev": true,
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "0.0.1",
+				"string_decoder": "0.10.31"
+			}
+		},
+		"request": {
+			"version": "2.79.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.11.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "2.0.6",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.17",
+				"oauth-sign": "0.8.2",
+				"qs": "6.3.2",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.4.3",
+				"uuid": "3.1.0"
+			}
+		},
+		"shelljs": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+			"dev": true
+		},
+		"shot": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/shot/-/shot-4.0.4.tgz",
+			"integrity": "sha512-V8wHSJSNqt8ZIgdbTQCFIrp5BwBH+tsFLNBL1REmkFN/0PJdmzUBQscZqsbdSvdLc+Qxq7J5mcwzai66vs3ozA==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2",
+				"joi": "13.0.2"
+			}
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
+			"requires": {
+				"hoek": "2.16.3"
+			},
+			"dependencies": {
+				"hoek": {
+					"version": "2.16.3",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+					"dev": true
+				}
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"statehood": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.5.tgz",
+			"integrity": "sha512-HPa8qT5sGTBVn1Fc9czBYR1oo7gBaay3ysnb04cvcF80YrDIV7880KpjmMj54j7CrFuQFfgMRb44QCRxRmAdTg==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"bounce": "1.2.0",
+				"cryptiles": "4.1.1",
+				"hoek": "5.0.2",
+				"iron": "5.0.4",
+				"joi": "13.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				},
+				"cryptiles": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
+					"integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
+					"dev": true,
+					"requires": {
+						"boom": "7.1.1"
+					}
+				}
+			}
+		},
+		"statsd-client": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.2.4.tgz",
+			"integrity": "sha1-OFZPyg0/S0ivnmHdAD/PmY5dS7k="
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+			"dev": true
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+			"dev": true
+		},
+		"subtext": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
+			"integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"content": "4.0.3",
+				"hoek": "5.0.2",
+				"pez": "4.0.1",
+				"wreck": "14.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"teamwork": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.1.tgz",
+			"integrity": "sha512-hEkJIpDOfOYe9NYaLFk00zQbzZeKNCY8T2pRH3I13Y1mJwxaSQ6NEsjY5rCp+11ezCiZpWGoGFTbOuhg4qKevQ==",
+			"dev": true
+		},
+		"topo": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+			"integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"travis-cov": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/travis-cov/-/travis-cov-0.2.5.tgz",
+			"integrity": "sha1-qyNvNvxoJZJju5LpEEQADdXLtzY=",
+			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+			"dev": true
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
+			"optional": true
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"dev": true
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				}
+			}
+		},
+		"vise": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
+			"integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
+			"dev": true,
+			"requires": {
+				"hoek": "5.0.2"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"wreck": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
+			"integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
+			"dev": true,
+			"requires": {
+				"boom": "7.1.1",
+				"hoek": "5.0.2"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+					"integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+					"dev": true,
+					"requires": {
+						"hoek": "5.0.2"
+					}
+				}
+			}
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -4,22 +4,22 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "6.0.0",
+	"version": "7.0.0",
 	"dependencies": {
 		"statsd-client": "^0.2.4",
-		"hoek": "^4.1.0"
+		"hoek": "^5.0.2"
 	},
 	"devDependencies": {
-		"mocha": "^1.21.5",
+		"mocha": "^4.0.1",
 		"jshint": "^2.9.4",
 		"travis-cov": "0.x.x",
 		"blanket": "^1.2.3",
-		"hapi": "^16.0.0",
+		"hapi": "^17.0.0",
 		"coveralls": "^2.11.15",
 		"mocha-lcov-reporter": "^0.0.2"
 	},
 	"peerDependencies": {
-		"hapi": "^16.0.0"
+		"hapi": "^17.0.0"
 	},
 	"keywords": [
 		"hapi",
@@ -33,7 +33,7 @@
 		"round trip"
 	],
 	"engines": {
-		"node": ">=4.0.0"
+		"node": ">=8.0.0"
 	},
 	"main": "./lib/hapi-statsd.js",
 	"repository": {

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -17,88 +17,77 @@ var assert = require('assert'),
 	},
 	Hapi = require('hapi');
 
-beforeEach(function(done) {
-	server = new Hapi.Server();
-
-	server.connection({
+beforeEach(async function() {
+	server = new Hapi.Server({
 		host: 'localhost',
 		port: 8085
 	});
 
+
 	var get = function (request, reply) {
-		reply('Success!');
+		return 'Success!';
 	};
 
 	var err = function (request, reply) {
-		reply(new Error());
+		return new Error();
 	};
 
 	server.route({ method: ['GET','OPTIONS'], path: '/', handler: get, config: {cors: true}});
 	server.route({ method: 'GET', path: '/err', handler: err, config: {cors: true} });
 	server.route({ method: 'GET', path: '/test/{param}', handler: get, config: {cors: true}});
 
-	server.register({
-		register: plugin,
-		options: { statsdClient: mockStatsdClient }
-	}, done);
+	try {
+		return await server.register({
+			plugin: plugin,
+			options: { statsdClient: mockStatsdClient }
+		});
+	} catch (error){
+		return error
+	}
 });
 
 describe('hapi-statsd plugin tests', function() {
 
 	it('should expose statsd client to the hapi server', function() {
-
 		assert.equal(server.statsd, mockStatsdClient);
 	});
 
-	it('should report stats with no path in stat name', function(done) {
-
-		server.inject('/', function (res) {
-			assert(mockStatsdClient.incStat == 'GET.200');
-			assert(mockStatsdClient.timingStat == 'GET.200');
-			assert(mockStatsdClient.timingDate instanceof Date);
-			done();
-		});
+	it('should report stats with no path in stat name', async function() {
+		await server.inject('/');
+		assert(mockStatsdClient.incStat == 'GET.200');
+		assert(mockStatsdClient.timingStat == 'GET.200');
+		assert(mockStatsdClient.timingDate instanceof Date);		
 	});
 
-	it('should report stats with path in stat name', function(done) {
-
-		server.inject('/test/123', function (res) {
-			assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
-			assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
-			assert(mockStatsdClient.timingDate instanceof Date);
-			done();
-		});
+	it('should report stats with path in stat name', async function() {
+		await server.inject('/test/123');
+		assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
+		assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
+		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
-	it('should report stats with generic not found path', function(done) {
-		server.inject('/fnord', function (res) {
-			assert(mockStatsdClient.incStat == '{notFound*}.GET.404');
-			assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
-			assert(mockStatsdClient.timingDate instanceof Date);
-			done();
-		});
+	it('should report stats with generic not found path', async function() {
+		await server.inject('/fnord')
+		assert(mockStatsdClient.incStat == '{notFound*}.GET.404');
+		assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
+		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
-	it('should report stats with generic CORS path', function(done) {
-		server.inject({
+	it('should report stats with generic CORS path', async function() {
+		await server.inject({
 			method: 'OPTIONS',
 			headers: {
 				Origin: 'http://test.domain.com'
 			},
 			url: '/'
-		}, function (res) {
-			assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200');
-			assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200');
-			assert(mockStatsdClient.timingDate instanceof Date);
-			done();
-		});
+		})
+		assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200');
+		assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200');
+		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
-	it('should not change the status code of a response', function(done) {
-
-		server.inject('/err', function (res) {
-			assert(res.statusCode === 500);
-			done();
-		});
+	it('should not change the status code of a response', async function() {
+		var res = await server.inject('/err')
+		assert(res.statusCode === 500);
 	});
 });


### PR DESCRIPTION
* Updates Hapi v17
* I've had to update mocha due to receiving `DeprecationWarning: child_process: options.customFds option is deprecated. Use options.stdio instead.` when running the unit tests

Ive tested this with my own server and this is working as expected.