### PR TITLE
Different identifier for increment and timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The prefix to add to every stat collected. Usually used for grouping a set of st
 
 A character or set of characters to replace the '/' (forward slash) characters in your URL path since forward slashes cannot be used in stat names. Defaults to `'_'`
 
+### `includeMetricTypeInName`
+
+A boolean to differentiate the metric names. If this is true, the metric names will contain `.counter` and `.timer` suffixes. Defaults to `false`
+
 
 ## Example
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -46,8 +46,8 @@ var register = function (server, options) {
 			.replace('{statusCode}', statusCode);
 
 		statName = (statName.indexOf('.') === 0) ? statName.substr(1) : statName;
-		statsdClient.increment(statName);
-		statsdClient.timing(statName, startDate);
+		statsdClient.increment(statName + '.counter');
+		statsdClient.timing(statName + '.timer', startDate);
 
 		return h.continue;
 	});

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -6,7 +6,8 @@ var StatsdClient = require('statsd-client'),
 		port: '8125',
 		prefix: 'hapi',
 		pathSeparator: '_',
-		template: '{path}.{method}.{statusCode}'
+		template: '{path}.{method}.{statusCode}',
+		includeMetricTypeInName: false
 	};
 
 var register = function (server, options) {
@@ -44,10 +45,12 @@ var register = function (server, options) {
 			.replace('{path}', normalizePath(path))
 			.replace('{method}', request.method.toUpperCase())
 			.replace('{statusCode}', statusCode);
+		var incrementSuffix = settings.includeMetricTypeInName ? '.counter' : '';
+		var timingSuffix = settings.includeMetricTypeInName ? '.timer' : '';
 
 		statName = (statName.indexOf('.') === 0) ? statName.substr(1) : statName;
-		statsdClient.increment(statName + '.counter');
-		statsdClient.timing(statName + '.timer', startDate);
+		statsdClient.increment(statName + incrementSuffix);
+		statsdClient.timing(statName + timingSuffix, startDate);
 
 		return h.continue;
 	});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "8.0.0",
+	"version": "7.1.0",
 	"dependencies": {
 		"statsd-client": "^0.2.4",
 		"hoek": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "7.0.0",
+	"version": "8.0.0",
 	"dependencies": {
 		"statsd-client": "^0.2.4",
 		"hoek": "^5.0.2"

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -54,22 +54,22 @@ describe('hapi-statsd plugin tests', function() {
 
 	it('should report stats with no path in stat name', async function() {
 		await server.inject('/');
-		assert(mockStatsdClient.incStat == 'GET.200.counter');
-		assert(mockStatsdClient.timingStat == 'GET.200.timer');
+		assert(mockStatsdClient.incStat == 'GET.200');
+		assert(mockStatsdClient.timingStat == 'GET.200');
 		assert(mockStatsdClient.timingDate instanceof Date);		
 	});
 
 	it('should report stats with path in stat name', async function() {
 		await server.inject('/test/123');
-		assert(mockStatsdClient.incStat == 'test_{param}.GET.200.counter');
-		assert(mockStatsdClient.timingStat == 'test_{param}.GET.200.timer');
+		assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
+		assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
 		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
 	it('should report stats with generic not found path', async function() {
 		await server.inject('/fnord')
-		assert(mockStatsdClient.incStat == '{notFound*}.GET.404.counter');
-		assert(mockStatsdClient.timingStat == '{notFound*}.GET.404.timer');
+		assert(mockStatsdClient.incStat == '{notFound*}.GET.404');
+		assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
 		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
@@ -81,8 +81,8 @@ describe('hapi-statsd plugin tests', function() {
 			},
 			url: '/'
 		})
-		assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200.counter');
-		assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200.timer');
+		assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200');
+		assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200');
 		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -54,22 +54,22 @@ describe('hapi-statsd plugin tests', function() {
 
 	it('should report stats with no path in stat name', async function() {
 		await server.inject('/');
-		assert(mockStatsdClient.incStat == 'GET.200');
-		assert(mockStatsdClient.timingStat == 'GET.200');
+		assert(mockStatsdClient.incStat == 'GET.200.counter');
+		assert(mockStatsdClient.timingStat == 'GET.200.timer');
 		assert(mockStatsdClient.timingDate instanceof Date);		
 	});
 
 	it('should report stats with path in stat name', async function() {
 		await server.inject('/test/123');
-		assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
-		assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
+		assert(mockStatsdClient.incStat == 'test_{param}.GET.200.counter');
+		assert(mockStatsdClient.timingStat == 'test_{param}.GET.200.timer');
 		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
 	it('should report stats with generic not found path', async function() {
 		await server.inject('/fnord')
-		assert(mockStatsdClient.incStat == '{notFound*}.GET.404');
-		assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
+		assert(mockStatsdClient.incStat == '{notFound*}.GET.404.counter');
+		assert(mockStatsdClient.timingStat == '{notFound*}.GET.404.timer');
 		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 
@@ -81,8 +81,8 @@ describe('hapi-statsd plugin tests', function() {
 			},
 			url: '/'
 		})
-		assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200');
-		assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200');
+		assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200.counter');
+		assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200.timer');
 		assert(mockStatsdClient.timingDate instanceof Date);
 	});
 


### PR DESCRIPTION
We have some problems to visualize the metrics as increment and timing functions are called with the same identifier. Adding '.counter' and '.timer' suffixes will differentiate them

