### PR TITLE
Add filter option to provide controls of which endpoints are monitored and what data is reported

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ server.statsd.set('your.set', 200);
 
 ## Version Compatibility
 
-### Currently compatible with: Hapi 8.x.x
+### Currently compatible with: Hapi 9.x.x
 
 * 0.1.x - Hapi 1.x.x
 * 0.2.x - Hapi 3.x.x
@@ -119,6 +119,7 @@ server.statsd.set('your.set', 200);
 * 1.0.x - Hapi 6.x.x
 * 1.1.x - Hapi 7.x.x
 * 1.2.x - Hapi 8.x.x
+* 2.x.x - Hapi 9.x.x
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ server.statsd.set('your.set', 200);
 
 ## Version Compatibility
 
-### Currently compatible with: Hapi 9.x.x
+### Currently compatible with: Hapi 10.x.x (Node v4)
 
 * 0.1.x - Hapi 1.x.x
 * 0.2.x - Hapi 3.x.x
@@ -120,6 +120,7 @@ server.statsd.set('your.set', 200);
 * 1.1.x - Hapi 7.x.x
 * 1.2.x - Hapi 8.x.x
 * 2.x.x - Hapi 9.x.x
+* 3.x.x - Hapi 10.x.x (Node v4)
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "1.3.0",
+	"version": "2.0.0",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"eidetic": "0.x.x",
@@ -16,12 +16,12 @@
 		"travis-cov": "0.x.x",
 		"blanket": "1.x.x",
 		"node-dependencies": "0.x.x",
-		"hapi": ">=8.x.x",
+		"hapi": "^9.0.0",
 		"coveralls": "2.x.x",
 		"mocha-lcov-reporter": "0.x.x"
 	},
 	"peerDependencies": {
-		"hapi": ">=8.x.x"
+		"hapi": "^9.0.0"
 	},
 	"keywords": [
 		"hapi",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"eidetic": "0.x.x",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"eidetic": "0.x.x",
-		"hoek": "2.x.x"
+		"hoek": "3.x.x"
 	},
 	"devDependencies": {
 		"mocha": "1.x.x",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"hoek": "3.x.x"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"blanket": "1.x.x",
 		"node-dependencies": "0.x.x",
 		"hapi": "8.x.x",
-		"coveralls": "2.10.x",
+		"coveralls": "2.x.x",
 		"mocha-lcov-reporter": "0.x.x"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"eidetic": "0.x.x",
@@ -16,12 +16,12 @@
 		"travis-cov": "0.x.x",
 		"blanket": "1.x.x",
 		"node-dependencies": "0.x.x",
-		"hapi": "^9.0.0",
+		"hapi": "^10.0.0",
 		"coveralls": "2.x.x",
 		"mocha-lcov-reporter": "0.x.x"
 	},
 	"peerDependencies": {
-		"hapi": "^9.0.0"
+		"hapi": "^10.0.0"
 	},
 	"keywords": [
 		"hapi",
@@ -35,7 +35,7 @@
 		"round trip"
 	],
 	"engines": {
-		"node": ">=0.10.0"
+		"node": ">=4.0.0"
 	},
 	"main": "./lib/hapi-statsd.js",
 	"repository": {


### PR DESCRIPTION
Closes https://github.com/mac-/hapi-statsd/issues/17

We have actually been using this feature on our branch for several years but it was never contributed back. If you are still interested please merge this PR.
This will add a feature to filter what data is reported to statsd. It can be configured by path, status code or route id. Both the counter or timer can be toggled with a filter. The readme changes probably explain in best:

### `defaultFilter`

Defines whether increment and timer stats are turned on by default. Defaults to `{ enableCounter: true, enableTimer: true }`.

### `filters`

An array of custom filters. A successful match requires one of these fields to be defined and match the route: 
* `id`: The route id defined in the route's config
* `path`: The path defined in the route
* `method`: The HTTP method of the request/route
* `status`: The returned HTTP status code of the response

Parameters that are not included are considered wildcard and will match all values. Note that if none of these 
parameters are included in the filter, then you will get a match on ALL route-response combinations.

In addition to matching, the field can contain the following configuration options:

* name: Defines a custom name for the stat to be reported
* enableTimer: Enable/disable the timer stat from being reported
* enableCounter: Enable/disable the count stat from being reported

Example configuration:
```js
defaultFilter: { // by default, enable timer and disable counter stats
    enableCounter: false,
    enableTimer: true,
}
filters: [
    { path: '/', enableCounter: true }, // enable counters (keep timers on as well) for this path
    { path: '/test/{param}', enableCounter: true }, // path with a parameter
    { path: '/rename', name: 'rename_stat' }, // rename the metric
    { id: 'match-my-id', enableCounter: true, enableTimer: true }, // match by route id
    { status: 407, name: 'match_on_status', enableCounter: true, enableTimer: true }, // match by status code
]
````