### PR TITLE
Update @hapi/hapi to 20.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Don't forget to bump the version in the `package.json` using the [semver](http:/
 To install this plugin on your Hapi server, do something similar to this:
 
 ```js
-var Hapi = require('hapi');
+var Hapi = require('@hapi/hapi');
 var server = new Hapi.Server();
 
 var hapiStatsdConfig = {};

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -1,5 +1,5 @@
 var StatsdClient = require('statsd-client'),
-	Hoek = require('hoek'),
+	Hoek = require('@hapi/hoek'),
 	defaults = {
 		statsdClient: null,
 		host: 'localhost',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,1743 @@
 {
 	"name": "hapi-statsd",
-	"version": "8.0.0",
-	"lockfileVersion": 1,
+	"version": "8.0.1",
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"version": "8.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"@hapi/hoek": "^9.2.0",
+				"statsd-client": "^0.4.6"
+			},
+			"devDependencies": {
+				"@hapi/hapi": "^20.1.2",
+				"blanket": "^1.2.3",
+				"coveralls": "^3.0.0",
+				"jshint": "^2.9.4",
+				"mocha": "^4.0.1",
+				"mocha-lcov-reporter": "^1.3.0",
+				"travis-cov": "^0.2.5"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"@hapi/hapi": "^20.1.2"
+			}
+		},
+		"node_modules/@hapi/accept": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+			"integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/ammo": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+			"integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/b64": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+			"integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/boom": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
+			"integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/bounce": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+			"integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
+		"node_modules/@hapi/call": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+			"integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/catbox": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+			"integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/podium": "4.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/catbox-memory": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+			"integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/content": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+			"integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/cryptiles": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+			"integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+			"integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+			"dev": true
+		},
+		"node_modules/@hapi/hapi": {
+			"version": "20.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.2.tgz",
+			"integrity": "sha512-yLppH93as7vw+uaAMVcHEB13eBojuzGhcX948y/CGukNRAlnPV+c1EJGbYPLXVffpH8wCNsI7TrTaeifSFS6Vw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/accept": "^5.0.1",
+				"@hapi/ammo": "^5.0.1",
+				"@hapi/boom": "^9.1.0",
+				"@hapi/bounce": "^2.0.0",
+				"@hapi/call": "^8.0.0",
+				"@hapi/catbox": "^11.1.1",
+				"@hapi/catbox-memory": "^5.0.0",
+				"@hapi/heavy": "^7.0.1",
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/mimos": "^5.0.0",
+				"@hapi/podium": "^4.1.1",
+				"@hapi/shot": "^5.0.5",
+				"@hapi/somever": "^3.0.0",
+				"@hapi/statehood": "^7.0.3",
+				"@hapi/subtext": "^7.0.3",
+				"@hapi/teamwork": "^5.1.0",
+				"@hapi/topo": "^5.0.0",
+				"@hapi/validate": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/heavy": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+			"integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+		},
+		"node_modules/@hapi/iron": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+			"integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/mimos": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+			"integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x",
+				"mime-db": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/nigel": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+			"integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/vise": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/pez": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+			"integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/nigel": "4.x.x"
+			}
+		},
+		"node_modules/@hapi/podium": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+			"integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/teamwork": "5.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/shot": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+			"integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/somever": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+			"integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/bounce": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/statehood": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+			"integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bounce": "2.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/iron": "6.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"node_modules/@hapi/subtext": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+			"integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/file": "2.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/pez": "^5.0.1",
+				"@hapi/wreck": "17.x.x"
+			}
+		},
+		"node_modules/@hapi/teamwork": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+			"integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hapi/topo": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+			"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/@hapi/validate": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+			"integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0"
+			}
+		},
+		"node_modules/@hapi/vise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+			"integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/@hapi/wreck": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+			"integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+			"dev": true,
+			"dependencies": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+			"integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+			"integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+			"dev": true,
+			"dependencies": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"node_modules/assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"node_modules/aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/blanket": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/blanket/-/blanket-1.2.3.tgz",
+			"integrity": "sha1-FRtJh8O9hFUrtfA7kO9fflkx5HM=",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^1.0.3",
+				"falafel": "~1.2.0",
+				"foreach": "^2.0.5",
+				"isarray": "0.0.1",
+				"object-keys": "^1.0.6",
+				"xtend": "~4.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.7"
+			}
+		},
+		"node_modules/boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"dev": true,
+			"dependencies": {
+				"hoek": "4.x.x"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"node_modules/caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"node_modules/cli": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+			"dev": true,
+			"dependencies": {
+				"exit": "0.1.2",
+				"glob": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=0.2.5"
+			}
+		},
+		"node_modules/co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true,
+			"engines": {
+				"iojs": ">= 1.0.0",
+				"node": ">= 0.12.0"
+			}
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/commander": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"node_modules/console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"dev": true,
+			"dependencies": {
+				"date-now": "^0.1.4"
+			}
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"node_modules/coveralls": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+			"integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+			"dev": true,
+			"dependencies": {
+				"js-yaml": "^3.6.1",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.5",
+				"minimist": "^1.2.0",
+				"request": "^2.79.0"
+			},
+			"bin": {
+				"coveralls": "bin/coveralls.js"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/cryptiles": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+			"integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
+			"deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+			"dev": true,
+			"dependencies": {
+				"boom": "5.x.x"
+			}
+		},
+		"node_modules/cryptiles/node_modules/boom": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+			"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+			"dev": true,
+			"dependencies": {
+				"hoek": "4.x.x"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/diff": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dom-serializer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "~1.1.1",
+				"entities": "~1.1.1"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/domelementtype": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+			"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+			"dev": true
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+			"dev": true
+		},
+		"node_modules/domelementtype": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"dev": true
+		},
+		"node_modules/domhandler": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+			"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"dependencies": {
+				"jsbn": "~0.1.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+			"dev": true
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
+		},
+		"node_modules/extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true,
+			"engines": [
+				"node >=0.6.0"
+			]
+		},
+		"node_modules/falafel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+			"integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^1.0.3",
+				"foreach": "^2.0.5",
+				"isarray": "0.0.1",
+				"object-keys": "^1.0.6"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+			"dev": true
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"node_modules/foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
+		"node_modules/forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"node_modules/getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"node_modules/glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/growl": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.x"
+			}
+		},
+		"node_modules/har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"dev": true,
+			"dependencies": {
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
+			},
+			"engines": {
+				"node": ">=4.5.0"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true,
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+			"deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+			"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "1",
+				"domhandler": "2.3",
+				"domutils": "1.5",
+				"entities": "1.0",
+				"readable-stream": "1.1"
+			}
+		},
+		"node_modules/http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.8",
+				"npm": ">=1.3.7"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"node_modules/is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"node_modules/isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"node_modules/jshint": {
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
+			"integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
+			"dev": true,
+			"dependencies": {
+				"cli": "~1.0.0",
+				"console-browserify": "1.1.x",
+				"exit": "0.1.x",
+				"htmlparser2": "3.8.x",
+				"lodash": "~4.17.19",
+				"minimatch": "~3.0.2",
+				"shelljs": "0.3.x",
+				"strip-json-comments": "1.0.x"
+			},
+			"bin": {
+				"jshint": "bin/jshint"
+			}
+		},
+		"node_modules/json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"node_modules/jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"node_modules/lcov-parse": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
+		},
+		"node_modules/log-driver": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.17",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"dev": true,
+			"dependencies": {
+				"mime-db": "~1.30.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"dependencies": {
+				"minimist": "0.0.8"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mkdirp/node_modules/minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
+		},
+		"node_modules/mocha": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
+			"dependencies": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.11.0",
+				"debug": "3.1.0",
+				"diff": "3.3.1",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.3",
+				"he": "1.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "4.4.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/mocha-lcov-reporter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+			"integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"node_modules/oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"node_modules/punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"node_modules/qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"dev": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"dev": true,
+			"dependencies": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"node_modules/shelljs": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+			"dev": true,
+			"bin": {
+				"shjs": "bin/shjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"dev": true,
+			"dependencies": {
+				"hoek": "4.x.x"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"node_modules/sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
+			"dependencies": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			},
+			"bin": {
+				"sshpk-conv": "bin/sshpk-conv",
+				"sshpk-sign": "bin/sshpk-sign",
+				"sshpk-verify": "bin/sshpk-verify"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/statsd-client": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.4.6.tgz",
+			"integrity": "sha512-OL3PAf0LhlFP8ZpxFm3Ue7dL3cV5o7PAsWDsQnx/iKXGVr8huYF/ui+OZEORerEDVRps7BCPAq5bWppMj1oMoA=="
+		},
+		"node_modules/string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+			"dev": true
+		},
+		"node_modules/stringstream": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+			"dev": true
+		},
+		"node_modules/strip-json-comments": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+			"dev": true,
+			"bin": {
+				"strip-json-comments": "cli.js"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+			"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^1.4.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/travis-cov": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/travis-cov/-/travis-cov-0.2.5.tgz",
+			"integrity": "sha1-qyNvNvxoJZJju5LpEEQADdXLtzY=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
+		},
+		"node_modules/uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"dev": true,
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
+		"node_modules/verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"node_modules/xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		}
+	},
 	"dependencies": {
+		"@hapi/accept": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+			"integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/ammo": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+			"integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/b64": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+			"integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/boom": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
+			"integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/bounce": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+			"integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
+		"@hapi/call": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+			"integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/catbox": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+			"integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/podium": "4.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"@hapi/catbox-memory": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+			"integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/content": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+			"integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x"
+			}
+		},
+		"@hapi/cryptiles": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+			"integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x"
+			}
+		},
+		"@hapi/file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+			"integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+			"dev": true
+		},
+		"@hapi/hapi": {
+			"version": "20.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.2.tgz",
+			"integrity": "sha512-yLppH93as7vw+uaAMVcHEB13eBojuzGhcX948y/CGukNRAlnPV+c1EJGbYPLXVffpH8wCNsI7TrTaeifSFS6Vw==",
+			"dev": true,
+			"requires": {
+				"@hapi/accept": "^5.0.1",
+				"@hapi/ammo": "^5.0.1",
+				"@hapi/boom": "^9.1.0",
+				"@hapi/bounce": "^2.0.0",
+				"@hapi/call": "^8.0.0",
+				"@hapi/catbox": "^11.1.1",
+				"@hapi/catbox-memory": "^5.0.0",
+				"@hapi/heavy": "^7.0.1",
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/mimos": "^5.0.0",
+				"@hapi/podium": "^4.1.1",
+				"@hapi/shot": "^5.0.5",
+				"@hapi/somever": "^3.0.0",
+				"@hapi/statehood": "^7.0.3",
+				"@hapi/subtext": "^7.0.3",
+				"@hapi/teamwork": "^5.1.0",
+				"@hapi/topo": "^5.0.0",
+				"@hapi/validate": "^1.1.1"
+			}
+		},
+		"@hapi/heavy": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+			"integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"@hapi/hoek": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+			"integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+		},
+		"@hapi/iron": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+			"integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+			"dev": true,
+			"requires": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/mimos": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+			"integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x",
+				"mime-db": "1.x.x"
+			}
+		},
+		"@hapi/nigel": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+			"integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^9.0.4",
+				"@hapi/vise": "^4.0.0"
+			}
+		},
+		"@hapi/pez": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+			"integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+			"dev": true,
+			"requires": {
+				"@hapi/b64": "5.x.x",
+				"@hapi/boom": "9.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/nigel": "4.x.x"
+			}
+		},
+		"@hapi/podium": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+			"integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/teamwork": "5.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"@hapi/shot": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+			"integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"@hapi/somever": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+			"integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+			"dev": true,
+			"requires": {
+				"@hapi/bounce": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/statehood": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+			"integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bounce": "2.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/cryptiles": "5.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/iron": "6.x.x",
+				"@hapi/validate": "1.x.x"
+			}
+		},
+		"@hapi/subtext": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+			"integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/content": "^5.0.2",
+				"@hapi/file": "2.x.x",
+				"@hapi/hoek": "9.x.x",
+				"@hapi/pez": "^5.0.1",
+				"@hapi/wreck": "17.x.x"
+			}
+		},
+		"@hapi/teamwork": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+			"integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+			"dev": true
+		},
+		"@hapi/topo": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+			"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"@hapi/validate": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+			"integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0"
+			}
+		},
+		"@hapi/vise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+			"integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "9.x.x"
+			}
+		},
+		"@hapi/wreck": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+			"integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+			"dev": true,
+			"requires": {
+				"@hapi/boom": "9.x.x",
+				"@hapi/bourne": "2.x.x",
+				"@hapi/hoek": "9.x.x"
+			}
+		},
 		"acorn": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
@@ -72,7 +1806,6 @@
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -98,14 +1831,6 @@
 			"dev": true,
 			"requires": {
 				"hoek": "4.x.x"
-			},
-			"dependencies": {
-				"hoek": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-					"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-					"dev": true
-				}
 			}
 		},
 		"brace-expansion": {
@@ -196,9 +1921,9 @@
 			}
 		},
 		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+			"integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
 			"dev": true,
 			"requires": {
 				"boom": "5.x.x"
@@ -212,12 +1937,6 @@
 					"requires": {
 						"hoek": "4.x.x"
 					}
-				},
-				"hoek": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-					"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-					"dev": true
 				}
 			}
 		},
@@ -311,7 +2030,6 @@
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
 			}
@@ -434,308 +2152,6 @@
 			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
 			"dev": true
 		},
-		"hapi": {
-			"version": "18.1.0",
-			"resolved": "https://registry.npmjs.org/hapi/-/hapi-18.1.0.tgz",
-			"integrity": "sha512-nSU1VLyTAgp7P5gy47QzJIP2JAb+wOFvJIV3gnL0lFj/mD+HuTXhyUsDYXjF/dhADMVXVEz31z6SUHBJhtsvGA==",
-			"dev": true,
-			"requires": {
-				"accept": "3.x.x",
-				"ammo": "3.x.x",
-				"boom": "7.x.x",
-				"bounce": "1.x.x",
-				"call": "5.x.x",
-				"catbox": "10.x.x",
-				"catbox-memory": "4.x.x",
-				"heavy": "6.x.x",
-				"hoek": "6.x.x",
-				"joi": "14.x.x",
-				"mimos": "4.x.x",
-				"podium": "3.x.x",
-				"shot": "4.x.x",
-				"somever": "2.x.x",
-				"statehood": "6.x.x",
-				"subtext": "6.x.x",
-				"teamwork": "3.x.x",
-				"topo": "3.x.x"
-			},
-			"dependencies": {
-				"accept": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-					"integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x"
-					}
-				},
-				"ammo": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.3.tgz",
-					"integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x"
-					}
-				},
-				"b64": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/b64/-/b64-4.1.2.tgz",
-					"integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x"
-					}
-				},
-				"boom": {
-					"version": "7.3.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-					"integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x"
-					}
-				},
-				"bounce": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.3.tgz",
-					"integrity": "sha512-3G7B8CyBnip5EahCZJjnvQ1HLyArC6P5e+xcolo13BVI9ogFaDOsNMAE7FIWliHtIkYI8/nTRCvCY9tZa3Mu4g==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x"
-					}
-				},
-				"bourne": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.1.tgz",
-					"integrity": "sha512-Ou0l3W8+n1FuTOoIfIrCk9oF9WVWc+9fKoAl67XQr9Ws0z7LgILRZ7qtc9xdT4BveSKtnYXfKPgn8pFAqeQRew==",
-					"dev": true
-				},
-				"call": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/call/-/call-5.0.3.tgz",
-					"integrity": "sha512-eX16KHiAYXugbFu6VifstSdwH6aMuWWb4s0qvpq1nR1b+Sf+u68jjttg8ixDBEldPqBi30bDU35OJQWKeTLKxg==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x"
-					}
-				},
-				"catbox": {
-					"version": "10.0.6",
-					"resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.6.tgz",
-					"integrity": "sha512-gQWCnF/jbHcfwGbQ4FQxyRiAwLRipqWTTXjpq7rTqqdcsnZosFa0L3LsCZcPTF33QIeMMkS7QmFBHt6QdzGPvg==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x",
-						"joi": "14.x.x"
-					}
-				},
-				"catbox-memory": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-4.0.1.tgz",
-					"integrity": "sha512-ZmqNiLsYCIu9qvBJ/MQbznDV2bFH5gFiH67TgIJgSSffJFtTXArT+MM3AvJQlby9NSkLHOX4eH/uuUqnch/Ldw==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x"
-					}
-				},
-				"content": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/content/-/content-4.0.6.tgz",
-					"integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x"
-					}
-				},
-				"cryptiles": {
-					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-					"integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x"
-					}
-				},
-				"heavy": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.2.tgz",
-					"integrity": "sha512-cJp884bqhiebNcEHydW0g6V1MUGYOXRPw9c7MFiHQnuGxtbWuSZpsbojwb2kxb3AA1/Rfs8CNiV9MMOF8pFRDg==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x",
-						"joi": "14.x.x"
-					}
-				},
-				"hoek": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-					"integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
-					"dev": true
-				},
-				"iron": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
-					"integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
-					"dev": true,
-					"requires": {
-						"b64": "4.x.x",
-						"boom": "7.x.x",
-						"cryptiles": "4.x.x",
-						"hoek": "6.x.x"
-					}
-				},
-				"joi": {
-					"version": "14.3.1",
-					"resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-					"integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x",
-						"isemail": "3.x.x",
-						"topo": "3.x.x"
-					}
-				},
-				"mime-db": {
-					"version": "1.37.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-					"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-					"dev": true
-				},
-				"mimos": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.2.tgz",
-					"integrity": "sha512-5XBsDqBqzSN88XPPH/TFpOalWOjHJM5Z2d3AMx/30iq+qXvYKd/8MPhqBwZDOLtoaIWInR3nLzMQcxfGK9djXA==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x",
-						"mime-db": "1.x.x"
-					}
-				},
-				"nigel": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
-					"integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x",
-						"vise": "3.x.x"
-					}
-				},
-				"pez": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/pez/-/pez-4.0.5.tgz",
-					"integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ==",
-					"dev": true,
-					"requires": {
-						"b64": "4.x.x",
-						"boom": "7.x.x",
-						"content": "4.x.x",
-						"hoek": "6.x.x",
-						"nigel": "3.x.x"
-					}
-				},
-				"podium": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/podium/-/podium-3.2.0.tgz",
-					"integrity": "sha512-rbwvxwVkI6gRRlxZQ1zUeafrpGxZ7QPHIheinehAvGATvGIPfWRkaTeWedc5P4YjXJXEV8ZbBxPtglNylF9hjw==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x",
-						"joi": "14.x.x"
-					}
-				},
-				"shot": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/shot/-/shot-4.0.7.tgz",
-					"integrity": "sha512-RKaKAGKxJ11EjJl0cf2fYVSsd4KB5Cncb9J0v7w+0iIaXpxNqFWTYNDNhBX7f0XSyDrjOH9a4OWZ9Gp/ZML+ew==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x",
-						"joi": "14.x.x"
-					}
-				},
-				"somever": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/somever/-/somever-2.0.0.tgz",
-					"integrity": "sha512-9JaIPP+HxwYGqCDqqK3tRaTqdtQHoK6Qy3IrXhIt2q5x8fs8RcfU7BMWlFTCOgFazK8p88zIv1tHQXvAwtXMyw==",
-					"dev": true,
-					"requires": {
-						"bounce": "1.x.x",
-						"hoek": "6.x.x"
-					}
-				},
-				"statehood": {
-					"version": "6.0.9",
-					"resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.9.tgz",
-					"integrity": "sha512-jbFg1+MYEqfC7ABAoWZoeF4cQUtp3LUvMDUGExL76cMmleBHG7I6xlZFsE8hRi7nEySIvutHmVlLmBe9+2R5LQ==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"bounce": "1.x.x",
-						"bourne": "1.x.x",
-						"cryptiles": "4.x.x",
-						"hoek": "6.x.x",
-						"iron": "5.x.x",
-						"joi": "14.x.x"
-					}
-				},
-				"subtext": {
-					"version": "6.0.12",
-					"resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.12.tgz",
-					"integrity": "sha512-yT1wCDWVgqvL9BIkWzWqgj5spUSYo/Enu09iUV8t2ZvHcr2tKGTGg2kc9tUpVEsdhp1ihsZeTAiDqh0TQciTPQ==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"bourne": "1.x.x",
-						"content": "4.x.x",
-						"hoek": "6.x.x",
-						"pez": "4.x.x",
-						"wreck": "14.x.x"
-					}
-				},
-				"teamwork": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.3.tgz",
-					"integrity": "sha512-OCB56z+G70iA1A1OFoT+51TPzfcgN0ks75uN3yhxA+EU66WTz2BevNDK4YzMqfaL5tuAvxy4iFUn35/u8pxMaQ==",
-					"dev": true
-				},
-				"topo": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-					"integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x"
-					}
-				},
-				"vise": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/vise/-/vise-3.0.2.tgz",
-					"integrity": "sha512-X52VtdRQbSBXdjcazRiY3eRgV3vTQ0B+7Wh8uC9cVv7lKfML5m9+9NHlbcgCY0R9EAqD1v/v7o9mhGh2A3ANFg==",
-					"dev": true,
-					"requires": {
-						"hoek": "6.x.x"
-					}
-				},
-				"wreck": {
-					"version": "14.1.3",
-					"resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.3.tgz",
-					"integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw==",
-					"dev": true,
-					"requires": {
-						"boom": "7.x.x",
-						"hoek": "6.x.x"
-					}
-				}
-			}
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -768,14 +2184,6 @@
 				"cryptiles": "3.x.x",
 				"hoek": "4.x.x",
 				"sntp": "2.x.x"
-			},
-			"dependencies": {
-				"hoek": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-					"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-					"dev": true
-				}
 			}
 		},
 		"he": {
@@ -785,9 +2193,10 @@
 			"dev": true
 		},
 		"hoek": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-			"integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+			"dev": true
 		},
 		"htmlparser2": {
 			"version": "3.8.3",
@@ -841,23 +2250,6 @@
 			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 			"dev": true
 		},
-		"isemail": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-			"integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-			"dev": true,
-			"requires": {
-				"punycode": "2.x.x"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-					"dev": true
-				}
-			}
-		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -878,20 +2270,19 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"jshint": {
-			"version": "2.9.5",
-			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
-			"integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
+			"integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
 			"dev": true,
 			"requires": {
 				"cli": "~1.0.0",
 				"console-browserify": "1.1.x",
 				"exit": "0.1.x",
 				"htmlparser2": "3.8.x",
-				"lodash": "3.7.x",
+				"lodash": "~4.17.19",
 				"minimatch": "~3.0.2",
 				"shelljs": "0.3.x",
 				"strip-json-comments": "1.0.x"
@@ -934,9 +2325,9 @@
 			"dev": true
 		},
 		"lodash": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-			"integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"log-driver": {
@@ -970,9 +2361,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mkdirp": {
@@ -993,9 +2384,9 @@
 			}
 		},
 		"mocha": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-			"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
 			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
@@ -1115,6 +2506,12 @@
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 			"dev": true
 		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
 		"shelljs": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
@@ -1128,14 +2525,6 @@
 			"dev": true,
 			"requires": {
 				"hoek": "4.x.x"
-			},
-			"dependencies": {
-				"hoek": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-					"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-					"dev": true
-				}
 			}
 		},
 		"sprintf-js": {
@@ -1145,9 +2534,9 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -1157,13 +2546,14 @@
 				"ecc-jsbn": "~0.1.1",
 				"getpass": "^0.1.1",
 				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
 			}
 		},
 		"statsd-client": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.4.5.tgz",
-			"integrity": "sha512-tmTpFMxpBcq92CTMq81d1W47GEazy76Hi+aNKvKJloMplQZe+L1jekSg95YG8ieq6j2Q9MboCaLIMdsF20+eGg=="
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.4.6.tgz",
+			"integrity": "sha512-OL3PAf0LhlFP8ZpxFm3Ue7dL3cV5o7PAsWDsQnx/iKXGVr8huYF/ui+OZEORerEDVRps7BCPAq5bWppMj1oMoA=="
 		},
 		"string_decoder": {
 			"version": "0.10.31",
@@ -1220,8 +2610,7 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,20 +6,20 @@
 	],
 	"version": "8.0.1",
 	"dependencies": {
-		"statsd-client": "^0.4.5",
-		"hoek": "^6.1.3"
+		"@hapi/hoek": "^9.2.0",
+		"statsd-client": "^0.4.6"
 	},
 	"devDependencies": {
-		"mocha": "^4.0.1",
-		"jshint": "^2.9.4",
-		"travis-cov": "^0.2.5",
+		"@hapi/hapi": "^20.1.2",
 		"blanket": "^1.2.3",
-		"hapi": "^18.0.0",
 		"coveralls": "^3.0.0",
-		"mocha-lcov-reporter": "^1.3.0"
+		"jshint": "^2.9.4",
+		"mocha": "^4.0.1",
+		"mocha-lcov-reporter": "^1.3.0",
+		"travis-cov": "^0.2.5"
 	},
 	"peerDependencies": {
-		"hapi": "^18.0.0"
+		"@hapi/hapi": "^20.1.2"
 	},
 	"keywords": [
 		"hapi",
@@ -33,7 +33,7 @@
 		"round trip"
 	],
 	"engines": {
-		"node": ">=8.0.0"
+		"node": ">=12.0.0"
 	},
 	"main": "./lib/hapi-statsd.js",
 	"repository": {

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -15,7 +15,7 @@ var assert = require('assert'),
 			this.timingDate = date;
 		}
 	},
-	Hapi = require('hapi');
+	Hapi = require('@hapi/hapi');
 
 beforeEach(async function() {
 	mockStatsdClient.incStat = '';


### PR DESCRIPTION
GIven the changes [in hapi](https://github.com/hapijs/hapi/issues/4114), this PR proposed to use version 20.1.2 of happy and its dependencies.